### PR TITLE
Added Markdown-based GitHub issue templates

### DIFF
--- a/.github/Issue_Template/bug-report.md
+++ b/.github/Issue_Template/bug-report.md
@@ -1,0 +1,56 @@
+---
+name: "🐞 Bug Report"
+about: "Report a bug to help improve the project"
+title: "🐛: "
+labels: ""
+assignees: ""
+---
+
+Thanks for helping us identify a bug!
+
+---
+
+### 🔍 Have You Searched Existing Issues?
+
+- [ ] I have searched the existing issues to avoid duplicates
+
+---
+
+### 🐞 Describe the Bug 
+
+What is happening and what should happen instead?
+
+---
+
+### ▶️ Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll to '...'
+4. See error
+
+---
+
+### ✅ Expected Behavior 
+
+What should have happened?
+
+---
+
+### 🖼️ Screenshots (If applicable) 
+
+Add screenshots to help explain the issue.
+
+---
+
+### 📘 Additional Context
+
+Any other details that might help.
+
+---
+
+### 🙌 Contributor Checklist
+
+- [ ] I agree to follow this project's Code of Conduct  
+- [ ] I am a SSOC contributor  
+- [ ] I want to work on this issue  

--- a/.github/Issue_Template/custom-issue.md
+++ b/.github/Issue_Template/custom-issue.md
@@ -1,0 +1,57 @@
+---
+name: "⚙️ Custom Issue"
+about: "Submit a custom issue or suggestion"
+title: '⚙️: '
+labels: ''
+assignees: ''
+---
+
+Thank you for submitting a custom issue for **NexTrade**!  
+This template is intended for any requests or suggestions that don't fit into the bug report, feature request, or documentation categories.
+
+---
+
+### 📝 Issue Summary  
+
+Provide a short summary of the custom issue.  
+_Example: Enhancement suggestion for the search functionality._
+
+---
+
+### 🔍 Issue Description  
+
+Describe the issue or suggestion in detail.  
+Include any relevant context, use case, or scenario where this issue occurs or is important.
+
+---
+
+### 💡 Proposed Solution (Optional)
+
+If you have any ideas or suggestions for solving this issue, describe them here.
+
+---
+
+### 📂 Category  
+
+_Select the category that best describes the issue:_
+
+- [ ] Enhancement  
+- [ ] Refactor  
+- [ ] Security  
+- [ ] Design  
+- [ ] Other  
+
+---
+
+### 📘 Additional Context   
+
+Add any other context, links, screenshots, or information that might be relevant.
+
+---
+
+### 🙌 Contributor Checklist
+
+- [ ] I have searched existing issues to avoid duplicates  
+- [ ] I agree to follow this project's Code of Conduct  
+- [ ] I am a SSOC contributor  
+- [ ] I want to work on this issue  

--- a/.github/Issue_Template/doc-update.md
+++ b/.github/Issue_Template/doc-update.md
@@ -1,0 +1,30 @@
+---
+name: "📑 Documentation Update"
+about: "Suggest updates or improvements to documentation"
+title: "📑: "
+labels: ""
+assignees: ""
+---
+
+Thank you for helping improve our documentation!
+
+---
+
+### 📝 What's wrong with the existing documentation?  
+
+Describe what needs to be fixed, added, or removed.
+
+---
+
+### 📎 Supporting Material  
+
+Attach screenshots, videos, or links that help explain your documentation update.
+
+---
+
+### 🙌 Contributor Checklist
+
+- [ ] I have reviewed the existing documentation  
+- [ ] I agree to follow this project's Code of Conduct  
+- [ ] I am a SSOC contributor  
+- [ ] I want to work on this issue  

--- a/.github/Issue_Template/feature-req.md
+++ b/.github/Issue_Template/feature-req.md
@@ -1,0 +1,48 @@
+---
+name: "✨ Feature Request"
+about: "Suggest a new feature or enhancement"
+title: "✨: "
+labels: ""
+assignees: ""
+---
+
+Thanks for suggesting a new feature!
+
+---
+
+### 💡 Problem Description
+  
+What problem are you facing that this feature would solve?
+
+---
+
+### ✅ Proposed Solution 
+
+Describe the feature you'd like to see added.
+
+---
+
+### 🔄 Alternatives Considered 
+
+Are there other ways you thought about solving this?
+
+---
+
+### 🖼️ Screenshots or Diagrams (Optional)
+
+Attach visuals or examples to support your idea.
+
+---
+
+### 📘 Additional Context 
+
+Include any additional information, links, or references.
+
+---
+
+### 🙌 Contributor Checklist
+
+- [ ] I have checked for similar feature requests  
+- [ ] I agree to follow this project's Code of Conduct  
+- [ ] I am a SSOC contributor  
+- [ ] I want to work on this issue  

--- a/.github/Issue_Template/performance-issue.md
+++ b/.github/Issue_Template/performance-issue.md
@@ -1,0 +1,41 @@
+---
+name: "⚡ Performance Issue"
+about: "Report a performance slowdown or bottleneck"
+title: "⚡: "
+labels: ""
+assignees: ""
+---
+
+Thanks for helping us identify performance issues!
+
+---
+
+### 📉 Describe the Performance Issue 
+
+What is slow or lagging? When does it happen?
+
+---
+
+### 🧪 Environment Details 
+
+OS, browser, device, version, etc.
+
+---
+
+### 🔁 Steps to Reproduce 
+
+Explain how someone else can experience this issue.
+
+---
+
+### 📋 Logs / Screenshots (Optional) 
+
+Paste logs or upload visuals that show the issue.
+
+---
+
+### 🙌 Contributor Checklist
+
+- [ ] I agree to follow this project's Code of Conduct  
+- [ ] I want to work on this issue  
+- [ ] I am a SSOC contributor

--- a/.github/Issue_Template/question.md
+++ b/.github/Issue_Template/question.md
@@ -1,0 +1,28 @@
+---
+name: "❓ Question / Help"
+about: "Ask a question or request support"
+title: "❓: "
+labels: ""
+assignees: ""
+---
+
+Have a question or need help? Ask here.
+
+---
+
+### 🧠 What's Your Question?
+  
+Be specific so others can help you quickly.
+
+---
+
+### 📘 Context  
+
+Include screenshots, links, or any other relevant info.
+
+---
+
+### 🙌 Contributor Checklist
+
+- [ ] I have searched existing issues  
+- [ ] I agree to follow this project's Code of Conduct  

--- a/.github/Issue_Template/ui-ux-fix.md
+++ b/.github/Issue_Template/ui-ux-fix.md
@@ -1,0 +1,35 @@
+---
+name: "🎨 UI/UX Suggestion"
+about: "Propose improvements to UI or user experience"
+title: "🎨: "
+labels: ""
+assignees: ""
+---
+
+Suggest improvements for the user interface or experience.
+
+---
+
+### 🖼️ Current UI/UX Behavior 
+
+Describe how the interface currently behaves or looks.
+
+---
+
+### ✨ Suggested Improvement
+
+What would you like to change or add?
+
+---
+
+### 📎 Screenshots / Visual Aids
+
+Mockups or screenshots help others understand your suggestion.
+
+---
+
+### 🙌 Contributor Checklist
+
+- [ ] I agree to follow this project's Code of Conduct  
+- [ ] I am a SSOC contributor  
+- [ ] I want to work on this issue  


### PR DESCRIPTION
Changes done:

Now contributors will raise issue according a specified template if they want a custom template then that is included too 
templates include :
📑 Documentation Update
🐞 Bug Report
✨ Feature Request
⚙️ Custom Issue
❓ Question / Help
🎨 UI/UX Suggestion
⚡ Performance Issue


closes #138 